### PR TITLE
Add background wind to divergent Nair-Lauritzen test case

### DIFF
--- a/transport/nair_lauritzen_divergent.py
+++ b/transport/nair_lauritzen_divergent.py
@@ -13,6 +13,7 @@ from firedrake import (exp, cos, sin, conditional, SpatialCoordinate,
 # 3. slotted_cylinder - Slotted Cylinder (Non-smooth scalar field)
 
 scalar_case = 'slotted_cylinder'
+background_flow = True
 
 ######################
 
@@ -51,7 +52,7 @@ output = OutputParameters(dirname=dirname,
 io = IO(domain, output)
 
 # get lat lon coordinates
-lamda, theta = latlon_coords(mesh)
+theta, lamda = latlon_coords(mesh)
 
 # Specify locations of the two bumps
 theta_c1 = 0.0
@@ -108,14 +109,19 @@ elif scalar_case == 'slotted_cylinder':
 else:
   raise NotImplementedError('Scalar case specified has not been implemented')
 
-k = 5*R/T
-
 # Set up the divergent, time-varying, velocity field
-def u_t(t):
-  u_background = 2*pi*R/T
-  lamda_prime = lamda - u_background*t
-  u_zonal = u_background*cos(theta) - k*(sin(lamda_prime/2)**2)*sin(2*theta)*(cos(theta)**2)*cos(pi*t/T)
-  u_merid = 0.5*k*sin(lamda_prime)*(cos(theta)**3)*cos(pi*t/T)
+if background_flow:
+  k = 5*R/T
+  def u_t(t):
+    u_background = 2*pi*R/T
+    lamda_prime = lamda - u_background*t
+    u_zonal = u_background*cos(theta) - k*(sin(lamda_prime/2)**2)*sin(2*theta)*(cos(theta)**2)*cos(pi*t/T)
+    u_merid = 0.5*k*sin(lamda_prime)*(cos(theta)**3)*cos(pi*t/T)
+else:
+  k = 10*R/T
+  def u_t(t):
+    u_zonal = - k*(sin(lamda/2)**2)*sin(2*theta)*(cos(theta)**2)*cos(pi*t/T)
+    u_merid = k*sin(lamda)*(cos(theta)**3)*cos(pi*t/T)
 
   cartesian_u_expr = -u_zonal*sin(lamda) - u_merid*sin(theta)*cos(lamda)
   cartesian_v_expr = u_zonal*cos(lamda) - u_merid*sin(theta)*sin(lamda)

--- a/transport/nair_lauritzen_divergent.py
+++ b/transport/nair_lauritzen_divergent.py
@@ -1,11 +1,8 @@
 from gusto import *
-from firedrake import IcosahedralSphereMesh, Constant, ge, le, exp, cos, \
-    sin, conditional, interpolate, SpatialCoordinate, VectorFunctionSpace, \
-    Function, assemble, dx, FunctionSpace, pi, min_value, acos
+from firedrake import (exp, cos, sin, conditional, SpatialCoordinate,
+                       as_vector, pi, min_value, acos)
 
-import numpy as np
-
-# This script runs the Nair_Laurtizen (2010) test cases with 
+# This script runs the Nair_Laurtizen (2010) test cases with
 # a divergent velocity field.
 
 ######################
@@ -21,8 +18,9 @@ scalar_case = 'slotted_cylinder'
 
 # Time parameters
 day = 24.*60.*60.
-dt = 300.
+dt = 300
 tmax = 12*day
+T = 12*day
 
 # Radius of the Earth
 R = 6371220.
@@ -47,14 +45,13 @@ dumpfreq = int(day/dt)
 output = OutputParameters(dirname=dirname,
                           dumplist_latlon=['D'],
                           dumpfreq = dumpfreq,
-                          log_level="INFO",
                           dump_nc = True,
                           dump_vtus = False)
-                          
+
 io = IO(domain, output)
 
 # get lat lon coordinates
-theta, lamda = latlon_coords(mesh)
+lamda, theta = latlon_coords(mesh)
 
 # Specify locations of the two bumps
 theta_c1 = 0.0
@@ -62,13 +59,13 @@ theta_c2 = 0.0
 lamda_c1 = -pi/4
 lamda_c2 = pi/4
 
-if scalar_case == 'cosine_bells': 
+if scalar_case == 'cosine_bells':
 
   R_t = R/2.
 
   def dist(lamda_, theta_, R0=R):
       return R0*acos(sin(theta_)*sin(theta) + cos(theta_)*cos(theta)*cos(lamda - lamda_))
-  
+
   d1 = min_value(1.0, dist(lamda_c1, theta_c1)/R_t)
   d2 = min_value(1.0, dist(lamda_c2, theta_c2)/R_t)
   Dexpr = 0.5*(1 + cos(pi*d1)) + 0.5*(1 + cos(pi*d2))
@@ -82,55 +79,56 @@ elif scalar_case == 'gaussian':
   X1 = cos(theta_c1)*cos(lamda_c1)
   Y1 = cos(theta_c1)*sin(lamda_c1)
   Z1 = sin(theta_c1)
-  
+
   X2 = cos(theta_c2)*cos(lamda_c2)
   Y2 = cos(theta_c2)*sin(lamda_c2)
-  Z2 = sin(theta_c2)   
-  
+  Z2 = sin(theta_c2)
+
   # Define the two Gaussian bumps
   g1 = exp(-5*((X-X1)**2 + (Y-Y1)**2 + (Z-Z1)**2))
   g2 = exp(-5*((X-X2)**2 + (Y-Y2)**2 + (Z-Z2)**2))
-  
+
   Dexpr = g1 + g2
 
 elif scalar_case == 'slotted_cylinder':
-      
+
   def dist1(lamda, theta, R0=R):
       return acos(sin(theta_c1)*sin(theta) + cos(theta_c1)*cos(theta)*cos(lamda - lamda_c1))
-      
+
   def dist2(lamda, theta, R0=R):
       return acos(sin(theta)*sin(theta_c2) + cos(theta)*cos(theta_c2)*cos(lamda_c2 - lamda))
-                  
+
   Dexpr = conditional( dist1(lamda, theta) < (1./2.), \
             conditional( (abs(lamda - lamda_c1) < (1./12.) ), \
               conditional( (theta - theta_c1) < (-5./24.), 1.0, 0.1), 1.0), \
                 conditional ( dist2(lamda, theta) < (1./2.), \
                   conditional( (abs(lamda - lamda_c2) < (1./12.) ), \
-                    conditional( (theta - theta_c2) > (5./24.), 1.0, 0.1), 1.0 ), 0.1 ))  
+                    conditional( (theta - theta_c2) > (5./24.), 1.0, 0.1), 1.0 ), 0.1 ))
 
 else:
   raise NotImplementedError('Scalar case specified has not been implemented')
 
-T = tmax
-k = 10*R/T
+k = 5*R/T
 
 # Set up the divergent, time-varying, velocity field
 def u_t(t):
-  u_zonal = -k*(sin(lamda/2)**2)*sin(2*theta)*(cos(theta)**2)*cos(pi*t/T)
-  u_merid = k*sin(lamda)*(cos(theta)**3)*cos(pi*t/T)
-  
+  u_background = 2*pi*R/T
+  lamda_prime = lamda - u_background*t
+  u_zonal = u_background*cos(theta) - k*(sin(lamda_prime/2)**2)*sin(2*theta)*(cos(theta)**2)*cos(pi*t/T)
+  u_merid = 0.5*k*sin(lamda_prime)*(cos(theta)**3)*cos(pi*t/T)
+
   cartesian_u_expr = -u_zonal*sin(lamda) - u_merid*sin(theta)*cos(lamda)
   cartesian_v_expr = u_zonal*cos(lamda) - u_merid*sin(theta)*sin(lamda)
   cartesian_w_expr = u_merid*cos(theta)
-  
+
   u_expr = as_vector((cartesian_u_expr, cartesian_v_expr, cartesian_w_expr))
-  
+
   return u_expr
 
 
-transport_scheme = SSPRK3(domain)
+transport_scheme = SSPRK3(domain, limiter=DG1Limiter(V))
 transport_method = DGUpwind(eqn, "D")
-    
+
 # Time stepper
 stepper = PrescribedTransport(eqn, transport_scheme, io, transport_method,
                               prescribed_transporting_velocity=u_t)


### PR DESCRIPTION
This adds a solid-body zonal background wind to the divergent Nair-Lauritzen test case (there is already one in the non-divergent case). I also added a limiter as I was running it with the cylinders!

My text editor also seems to have removed a bunch of white space and highlighted some unused imported variables.

Here are some plots (note I ran this on the cubed sphere, but in the script here it is the icosahedral sphere)

![nair_lauritzen_00](https://github.com/firedrakeproject/gusto_case_studies/assets/14180399/a6dd8151-5a07-4299-aee8-7eb29b7bf840)
![nair_lauritzen_12](https://github.com/firedrakeproject/gusto_case_studies/assets/14180399/d077333f-8c24-417d-a38a-69988f64d599)
![nair_lauritzen_24](https://github.com/firedrakeproject/gusto_case_studies/assets/14180399/0569b24d-2b8d-40f1-adec-0010791fe9a8)


