### PR TITLE
Pick up move to Omega in gusto main

### DIFF
--- a/compressible_euler/dry_baroclinic_sphere.py
+++ b/compressible_euler/dry_baroclinic_sphere.py
@@ -12,9 +12,8 @@ from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 
 from firedrake import (
     ExtrudedMesh, SpatialCoordinate, cos, sin, pi, sqrt, exp, Constant,
-    Function, as_vector, acos, errornorm, norm, le, ge, conditional,
-    NonlinearVariationalProblem, NonlinearVariationalSolver, TestFunction,
-    inner, dx
+    Function, acos, errornorm, norm, le, ge, conditional, inner, dx,
+    NonlinearVariationalProblem, NonlinearVariationalSolver, TestFunction
 )
 from gusto import (
     Domain, GeneralCubedSphereMesh, CompressibleParameters, CompressibleSolver,

--- a/compressible_euler/dry_baroclinic_sphere.py
+++ b/compressible_euler/dry_baroclinic_sphere.py
@@ -94,10 +94,9 @@ def dry_baroclinic_sphere(
     )
 
     # Equations
-    params = CompressibleParameters()
-    omega_vec = as_vector([0, 0, Constant(omega)])
+    params = CompressibleParameters(Omega=omega)
     eqn = CompressibleEulerEquations(
-        domain, params, Omega=omega_vec, u_transport_option=u_eqn_type
+        domain, params, u_transport_option=u_eqn_type
     )
 
     # Outputting and IO

--- a/compressible_euler/moist_baroclinic_channel.py
+++ b/compressible_euler/moist_baroclinic_channel.py
@@ -89,11 +89,10 @@ def moist_baroclinic_channel(
     x, y, z = SpatialCoordinate(mesh)
 
     # Equation
-    params = CompressibleParameters()
+    params = CompressibleParameters(Omega=omega*sin(phi0))
     tracers = [WaterVapour(), CloudWater()]
-    coriolis = 2*omega*sin(phi0)*domain.k
     eqns = CompressibleEulerEquations(
-        domain, params, active_tracers=tracers, Omega=coriolis/2,
+        domain, params, active_tracers=tracers,
         no_normal_flow_bc_ids=[1, 2], u_transport_option=u_eqn_type
     )
 


### PR DESCRIPTION
This should fix the case studies test suite, by picking up on the change to moving Omega out of the compressible equations and into the parameters.