### PR TITLE
Specify that build runners run Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: "Build Gusto"
     # The type of runner that the job will run on
-    runs-on: self-hosted
+    runs-on: [self-hosted, Linux]
     # The docker container to use.
     container:
       image: firedrakeproject/firedrake-vanilla:latest


### PR DESCRIPTION
This is in preparation for the rollout of Mac runners.

