### PR TITLE
Cancel running build jobs on new push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,13 @@ on:
     # Scheduled build at 0330 UTC on Monday mornings to detect bitrot.
     - cron:  '0 3 * * 2'
 
+concurrency:
+  # Cancels jobs running if new commits are pushed
+  group: >
+    ${{ github.workflow }}-
+    ${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: "Build Gusto"


### PR DESCRIPTION
This copies over the changes from the main Gusto repository to avoid lots of pushes to the same branch generating lots of concurrent jobs