### PR TITLE
Put mesh into parameters

### DIFF
--- a/case_studies/compressible_euler/dry_baroclinic_sphere.py
+++ b/case_studies/compressible_euler/dry_baroclinic_sphere.py
@@ -93,7 +93,7 @@ def dry_baroclinic_sphere(
     )
 
     # Equations
-    params = CompressibleParameters(Omega=omega)
+    params = CompressibleParameters(mesh, Omega=omega)
     eqn = CompressibleEulerEquations(
         domain, params, u_transport_option=u_eqn_type
     )

--- a/case_studies/compressible_euler/moist_baroclinic_channel.py
+++ b/case_studies/compressible_euler/moist_baroclinic_channel.py
@@ -89,7 +89,7 @@ def moist_baroclinic_channel(
     x, y, z = SpatialCoordinate(mesh)
 
     # Equation
-    params = CompressibleParameters(Omega=omega*sin(phi0))
+    params = CompressibleParameters(mesh, Omega=omega*sin(phi0))
     tracers = [WaterVapour(), CloudWater()]
     eqns = CompressibleEulerEquations(
         domain, params, active_tracers=tracers,

--- a/case_studies/compressible_euler/moist_bryan_fritsch.py
+++ b/case_studies/compressible_euler/moist_bryan_fritsch.py
@@ -72,7 +72,7 @@ def moist_bryan_fritsch(
     domain = Domain(mesh, dt, 'CG', element_order)
 
     # Equation
-    params = CompressibleParameters()
+    params = CompressibleParameters(mesh)
     tracers = [WaterVapour(), CloudWater()]
     eqns = CompressibleEulerEquations(
         domain, params, active_tracers=tracers, u_transport_option=u_eqn_type)

--- a/case_studies/compressible_euler/moist_skamarock_klemp.py
+++ b/case_studies/compressible_euler/moist_skamarock_klemp.py
@@ -74,7 +74,7 @@ def moist_skamarock_klemp(
     domain = Domain(mesh, dt, "CG", element_order)
 
     # Equation
-    parameters = CompressibleParameters()
+    parameters = CompressibleParameters(mesh)
     tracers = [WaterVapour(), CloudWater()]
     eqns = CompressibleEulerEquations(
         domain, parameters, active_tracers=tracers,

--- a/case_studies/compressible_euler/mountain_hydrostatic.py
+++ b/case_studies/compressible_euler/mountain_hydrostatic.py
@@ -100,7 +100,7 @@ def mountain_hydrostatic(
     # Equation
     parameters = CompressibleParameters(mesh, g=g, cp=cp)
     sponge = SpongeLayerParameters(
-        H=domain_height, z_level=domain_height-sponge_depth, mubar=mu_dt/dt
+        mesh, H=domain_height, z_level=domain_height-sponge_depth, mubar=mu_dt/dt
     )
     if hydrostatic:
         eqns = HydrostaticCompressibleEulerEquations(

--- a/case_studies/compressible_euler/mountain_hydrostatic.py
+++ b/case_studies/compressible_euler/mountain_hydrostatic.py
@@ -98,7 +98,7 @@ def mountain_hydrostatic(
     domain = Domain(mesh, dt, "CG", element_order)
 
     # Equation
-    parameters = CompressibleParameters(g=g, cp=cp)
+    parameters = CompressibleParameters(mesh, g=g, cp=cp)
     sponge = SpongeLayerParameters(
         H=domain_height, z_level=domain_height-sponge_depth, mubar=mu_dt/dt
     )

--- a/case_studies/compressible_euler/mountain_nonhydrostatic.py
+++ b/case_studies/compressible_euler/mountain_nonhydrostatic.py
@@ -101,7 +101,7 @@ def mountain_nonhydrostatic(
     # Equation
     parameters = CompressibleParameters(mesh, g=g, cp=cp)
     sponge = SpongeLayerParameters(
-        H=domain_height, z_level=domain_height-sponge_depth, mubar=mu_dt/dt
+        mesh, H=domain_height, z_level=domain_height-sponge_depth, mubar=mu_dt/dt
     )
     if hydrostatic:
         eqns = HydrostaticCompressibleEulerEquations(

--- a/case_studies/compressible_euler/mountain_nonhydrostatic.py
+++ b/case_studies/compressible_euler/mountain_nonhydrostatic.py
@@ -99,7 +99,7 @@ def mountain_nonhydrostatic(
     domain = Domain(mesh, dt, "CG", element_order)
 
     # Equation
-    parameters = CompressibleParameters(g=g, cp=cp)
+    parameters = CompressibleParameters(mesh, g=g, cp=cp)
     sponge = SpongeLayerParameters(
         H=domain_height, z_level=domain_height-sponge_depth, mubar=mu_dt/dt
     )

--- a/case_studies/compressible_euler/robert_bubble.py
+++ b/case_studies/compressible_euler/robert_bubble.py
@@ -69,7 +69,7 @@ def robert_bubble(
     domain = Domain(mesh, dt, "CG", element_order)
 
     # Equation
-    parameters = CompressibleParameters()
+    parameters = CompressibleParameters(mesh)
     eqns = CompressibleEulerEquations(
         domain, parameters, u_transport_option=u_eqn_type
     )

--- a/case_studies/compressible_euler/skamarock_klemp_hydrostatic.py
+++ b/case_studies/compressible_euler/skamarock_klemp_hydrostatic.py
@@ -79,7 +79,7 @@ def skamarock_klemp_hydrostatic(
     domain = Domain(mesh, dt, "RTCF", element_order)
 
     # Equation
-    parameters = CompressibleParameters(Omega=Omega)
+    parameters = CompressibleParameters(mesh, Omega=Omega)
     balanced_pg = as_vector((0., pressure_gradient_y, 0.))
     if hydrostatic:
         eqns = HydrostaticCompressibleEulerEquations(

--- a/case_studies/shallow_water/galewsky_jet.py
+++ b/case_studies/shallow_water/galewsky_jet.py
@@ -71,7 +71,7 @@ def galewsky_jet(
 
     # Equation
     xyz = SpatialCoordinate(mesh)
-    parameters = ShallowWaterParameters(H=H)
+    parameters = ShallowWaterParameters(mesh, H=H)
     Omega = parameters.Omega
     fexpr = 2*Omega*xyz[2]/radius
     eqns = ShallowWaterEquations(

--- a/case_studies/shallow_water/shallow_water_pangea.py
+++ b/case_studies/shallow_water/shallow_water_pangea.py
@@ -72,7 +72,7 @@ def shallow_water_pangea(
 
     # Equation
     xyz = SpatialCoordinate(mesh)
-    parameters = ShallowWaterParameters(H=H)
+    parameters = ShallowWaterParameters(mesh, H=H)
     Omega = parameters.Omega
     fexpr = 2*Omega*xyz[2]/radius
     bexpr = b_field

--- a/case_studies/thermal_shallow_water/moist_thermal_gravity_wave.py
+++ b/case_studies/thermal_shallow_water/moist_thermal_gravity_wave.py
@@ -60,7 +60,7 @@ def moist_thermal_gw(
     xyz = SpatialCoordinate(mesh)
 
     # Equation parameters
-    parameters = ShallowWaterParameters(H=mean_depth)
+    parameters = ShallowWaterParameters(mesh, H=mean_depth)
     Omega = parameters.Omega
     fexpr = 2*Omega*xyz[2]/radius
 

--- a/case_studies/thermal_shallow_water/thermal_galewsky_jet.py
+++ b/case_studies/thermal_shallow_water/thermal_galewsky_jet.py
@@ -71,7 +71,7 @@ def thermal_galewsky(
     xyz = SpatialCoordinate(mesh)
 
     # Equation
-    parameters = ShallowWaterParameters(H=mean_depth, g=g)
+    parameters = ShallowWaterParameters(mesh, H=mean_depth, g=g)
     Omega = parameters.Omega
     fexpr = 2*Omega*xyz[2]/radius
     eqns = ThermalShallowWaterEquations(

--- a/case_studies/thermal_shallow_water/thermal_williamson_5.py
+++ b/case_studies/thermal_shallow_water/thermal_williamson_5.py
@@ -71,7 +71,7 @@ def thermal_williamson_5(
     lamda, phi, _ = lonlatr_from_xyz(x, y, z)
 
     # Coriolis
-    parameters = ShallowWaterParameters(H=mean_depth, g=g)
+    parameters = ShallowWaterParameters(mesh, H=mean_depth, g=g)
     Omega = parameters.Omega
     fexpr = 2*Omega*z/radius
 


### PR DESCRIPTION
Updates the case studies to pass the mesh to parameters, which will need to be done when the Adjoint is enabled in Gusto to keep these working