### PR TITLE
Set Skamarock-Klemp hydrostatic gravity wave to use mesh of width 3

### DIFF
--- a/case_studies/compressible_euler/skamarock_klemp_hydrostatic.py
+++ b/case_studies/compressible_euler/skamarock_klemp_hydrostatic.py
@@ -73,7 +73,7 @@ def skamarock_klemp_hydrostatic(
 
     # Domain -- 3D volume mesh
     base_mesh = PeriodicRectangleMesh(
-        ncolumns, 1, domain_width, domain_length, quadrilateral=True
+        ncolumns, 3, domain_width, domain_length/3.0, quadrilateral=True
     )
     mesh = ExtrudedMesh(base_mesh, nlayers, layer_height=domain_height/nlayers)
     domain = Domain(mesh, dt, "RTCF", element_order)


### PR DESCRIPTION
Sets the mesh to be of width 3 in the y-direction to get around what I think is a problem with the facet normals, described in https://github.com/firedrakeproject/firedrake/issues/5266

This should get the test suite passing again.